### PR TITLE
exclude static fields from partial generation

### DIFF
--- a/stardao-kotlin-partial/src/main/kotlin/io/stardog/stardao/kotlin/partial/processor/PartialDataObjectsProcessor.kt
+++ b/stardao-kotlin-partial/src/main/kotlin/io/stardog/stardao/kotlin/partial/processor/PartialDataObjectsProcessor.kt
@@ -157,7 +157,7 @@ class PartialDataObjectsProcessor: AbstractProcessor() {
 
             val required = getFieldRequired(it, partialType)
 
-            if (it.kind == ElementKind.FIELD && propertyName != "Companion" && required != PartialFieldRequired.ABSENT) {
+            if (it.kind == ElementKind.FIELD && !it.modifiers.contains(Modifier.STATIC) && required != PartialFieldRequired.ABSENT) {
                 val isNullable = required == PartialFieldRequired.OPTIONAL
                 val className = getPartialFieldAnnotationClassName(it, partialType)
                 val propertyType: TypeName


### PR DESCRIPTION
When `PartialDataObjectsProcessor` generates a partial class, it includes properties that are defined in a data class' companion object. This causes a compile error, since the partial's constructor tries to grab a value for that property from an instance of the data class from which it was generated.

This change excludes elements that have `Modifier.STATIC` in their list of modifiers. I also removed the check for `propertyName != "Companion"` since this field element is static as well.